### PR TITLE
handle signals correctly for clean shutdown

### DIFF
--- a/run-services.sh
+++ b/run-services.sh
@@ -2,10 +2,20 @@
 
 shutdown() {
     ${TEAMCITY_DIST}/bin/teamcity-server.sh stop
+    exit 0
 }
 
 rm -f ${TEAMCITY_LOGS}/*.pid
 
 trap 'shutdown' SIGTERM SIGINT SIGHUP
 
-/bin/bash -c  "${TEAMCITY_DIST}/bin/teamcity-server.sh run"
+${TEAMCITY_DIST}/bin/teamcity-server.sh start
+
+while [ ! -f ${TEAMCITY_DIST}/logs/teamcity-server.log ];
+do
+   echo -n "."
+   sleep 1
+done
+
+tail -F ${TEAMCITY_DIST}/logs/teamcity-server.log &
+wait


### PR DESCRIPTION
Similar to changes made to agent docker image, call teamcity-server.sh using 'run ' rather than 'start' so correct pid file is created. Wait until signal is trapped to cleanly shutdown server.