### PR TITLE
Adding note on how to use run-services.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,15 @@ If you need to build your own image, you need to perform the following:
     docker build -t teamcity-server
    ```
 
+If you want to extend this image with your own setup scripts, you can place them in `/services` and the `run-services.sh`
+script will run them before starting TeamCity server.  You can add your scripts with a `COPY` instruction in the Dockerfile,
+or better yet, in a new image based on this one:
+
+   ```Dockerfile
+   FROM jetbrains/teamcity-server
+   COPY my-special-setup-script.sh /services/
+   ```
+    
+
+
 See our [detailed instructions](https://hub.docker.com/r/jetbrains/teamcity-server/) on how to use the image in the Docker Hub repository .

--- a/README.md
+++ b/README.md
@@ -36,7 +36,5 @@ or better yet, in a new image based on this one:
    FROM jetbrains/teamcity-server
    COPY my-special-setup-script.sh /services/
    ```
-    
-
 
 See our [detailed instructions](https://hub.docker.com/r/jetbrains/teamcity-server/) on how to use the image in the Docker Hub repository .


### PR DESCRIPTION
I didn't notice `run-services.sh` at first, but it's pretty useful.  I added a short note it to the README so other people might find it.