### PR TITLE
Added Ubuntu Perforce package

### DIFF
--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -10,9 +10,26 @@ EXPOSE 8111
 LABEL dockerImage.teamcity.version="latest" \
       dockerImage.teamcity.buildNumber="latest"
 
-RUN apt-get update && \
-    apt-get install -y git mercurial ca-certificates && \
-    apt-get clean all
+RUN buildDeps=' \
+        gnupg \
+    ' \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends $buildDeps \
+    && curl -fsSL https://package.perforce.com/perforce.pubkey | apt-key add - \
+    && mkdir -p /etc/apt/sources.list.d \
+    && ( \
+        . /etc/os-release && \
+        echo "deb http://package.perforce.com/apt/$ID $VERSION_CODENAME release" \ 
+	 > /etc/apt/sources.list.d/perforce.list \
+    ) \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git \
+        helix-cli \
+        mercurial \
+    && apt-get purge -y --auto-remove $buildDeps \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY welcome.sh /welcome.sh
 RUN chmod +x /welcome.sh && sync && \


### PR DESCRIPTION
Added Perforce binary to Ubuntu Dockerfile. Its installed using the [instructions ](https://www.perforce.com/perforce-packages) supplied by Perforce, and done using os-release so that it will install the correct package regardless of any base image changes.

Doing so required an intermediary gnupg package that is only installed during the build and then removed immediately. I also took the liberty of cleaning the downloaded apt lists which reduces the overall image size, and is recommended in the [Docker Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/). I also modified the existing RUN command to follow these practices as well, such as moving the install packages to new lines for better diffs and ordering them alphabetically. I also moved the AND operators to the front as its easier to see which lines are a new command versus an argument.